### PR TITLE
Fix eos_token_id error

### DIFF
--- a/tokenize_dataset_rows.py
+++ b/tokenize_dataset_rows.py
@@ -13,7 +13,7 @@ def preprocess(tokenizer, example, max_seq_length):
     target_ids = tokenizer.encode(
         target, max_length=max_seq_length, truncation=True, add_special_tokens=False
     )
-    input_ids = prompt_ids + target_ids + [tokenizer.eos_token_id]
+    input_ids = prompt_ids + target_ids + [150005]
     return {"input_ids": input_ids, "seq_len": len(prompt_ids)}
 
 


### PR DESCRIPTION
`tokenizer.eos_token_id` outputs 20002, but the `eos_token_id` defined in the [config.json](https://huggingface.co/THUDM/chatglm-6b/blob/main/config.json) of ChatGLM-6B is , so it needs to be changed to 150005.

<img width="253" alt="image" src="https://user-images.githubusercontent.com/10473170/227447620-0ba252fc-299d-4b28-b3a1-db8bc2039c6f.png">

```json
{
  "_name_or_path": "THUDM/chatglm-6b",
  "architectures": [
    "ChatGLMModel"
  ],
  "auto_map": {
    "AutoConfig": "configuration_chatglm.ChatGLMConfig",
    "AutoModel": "modeling_chatglm.ChatGLMForConditionalGeneration",
    "AutoModelForSeq2SeqLM": "modeling_chatglm.ChatGLMForConditionalGeneration"
  },
  "bos_token_id": 150004,
  "eos_token_id": 150005,
  "hidden_size": 4096,
  "inner_hidden_size": 16384,
  "layernorm_epsilon": 1e-05,
  "max_sequence_length": 2048,
  "model_type": "chatglm",
  "num_attention_heads": 32,
  "num_layers": 28,
  "position_encoding_2d": true,
  "torch_dtype": "float16",
  "transformers_version": "4.23.1",
  "use_cache": true,
  "vocab_size": 150528
}
```
