### PR TITLE
Fix save_model

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -104,6 +104,12 @@ class ModifiedTrainer(Trainer):
             labels=inputs["labels"],
         ).loss
 
+    def save_model(self, output_dir=None, _internal_call=False):
+        from transformers.trainer import TRAINING_ARGS_NAME
+        os.makedirs(output_dir, exist_ok=True)
+        torch.save(self.args, os.path.join(output_dir, TRAINING_ARGS_NAME))
+        save_tunable_parameters(self.model, os.path.join(output_dir, "chatglm-lora.pt"))
+
 
 def save_tunable_parameters(model, path):
     saved_params = {


### PR DESCRIPTION
The original save_model function saved all parameters, resulting in a file size of 6GB, while the actual Lora model is only 200MB and does not require such a large file. The modified save_model function uses the save_tunable_parameters function, which saves only the tunable parameters and reduces the saved model size to 200MB.

Before:

```
(base) ➜  ChatGLM-Tuning tree -h exp1
ykx_5k
├── [224M]  chatglm-lora.pt
├── [4.0K]  checkpoint-1000
│   ├── [448M]  optimizer.pt
│   ├── [6.6G]  pytorch_model.bin
│   ├── [ 14K]  rng_state_0.pth
│   ├── [ 14K]  rng_state_1.pth
│   ├── [ 14K]  rng_state_2.pth
│   ├── [ 14K]  rng_state_3.pth
│   ├── [ 14K]  rng_state_4.pth
│   ├── [ 14K]  rng_state_5.pth
│   ├── [ 14K]  rng_state_6.pth
│   ├── [ 14K]  rng_state_7.pth
│   ├── [ 557]  scaler.pt
│   ├── [ 627]  scheduler.pt
│   ├── [2.5K]  trainer_state.json
│   └── [3.5K]  training_args.bin
......
```

After:

```
(base) ➜  ChatGLM-Tuning tree -h exp2
.
├── [4.0K]  checkpoint-1000
│   ├── [224M]  chatglm-lora.pt
│   ├── [448M]  optimizer.pt
│   ├── [ 14K]  rng_state_0.pth
│   ├── [ 14K]  rng_state_1.pth
│   ├── [ 14K]  rng_state_2.pth
│   ├── [ 14K]  rng_state_3.pth
│   ├── [ 14K]  rng_state_4.pth
│   ├── [ 14K]  rng_state_5.pth
│   ├── [ 14K]  rng_state_6.pth
│   ├── [ 14K]  rng_state_7.pth
│   ├── [ 557]  scaler.pt
│   ├── [ 627]  scheduler.pt
│   ├── [2.6K]  trainer_state.json
│   └── [3.5K]  training_args.bin
......
```
