### PR TITLE
chore: two minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tokenization
 python tokenize_dataset_rows.py \
     --jsonl_path data/alpaca_data.jsonl \
     --save_path data/alpaca \
-    --max_seq_length 200 \ 
+    --max_seq_length 200 \
     --skip_overlength
 ```
 

--- a/cover_alpaca2jsonl.py
+++ b/cover_alpaca2jsonl.py
@@ -23,7 +23,7 @@ def main():
 
     with open(args.save_path, 'w') as f:
         for example in tqdm(examples, desc="formatting.."):
-            f.write(json.dumps(format_example(example)) + '\n')
+            f.write(json.dumps(format_example(example), ensure_ascii=False) + '\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
两处小修正

1. 去掉了`README`中`python tokenize_dataset_rows.py`参数的多余空格，多余空格使转义符转义到空格上了。
2. `cover_alpaca2jsonl.py`中`json.dumps`时，中文字符会被转义，生成的`jsonl`文件可读性略差，当然`json.loads`会转义回来不影响功能。

```
>>> import json
>>> print(json.dumps({ "intro": "测试"}))
{"intro": "\u6d4b\u8bd5"}
>>> print(json.dumps({ "intro": "测试" }, ensure_ascii=False))
{"intro": "测试"}
>>> print(json.loads('{"intro": "\u6d4b\u8bd5"}'))
{'intro': '测试'}
>>> print(json.loads('{"intro": "测试"}'))
{'intro': '测试'}
```
