### PR TITLE
Fix commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ```bash
 python cover_alpaca2jsonl.py \
     --data_path data/alpaca_data.json \
-    --save_path data/alpaca_data.jsonl \
+    --save_path data/alpaca_data.jsonl
 ```
 
 tokenization
@@ -45,7 +45,7 @@ tokenization
 python tokenize_dataset_rows.py \
     --jsonl_path data/alpaca_data.jsonl \
     --save_path data/alpaca \
-    --max_seq_length 200 \ 
+    --max_seq_length 200 \
     --skip_overlength
 ```
 

--- a/tokenize_dataset_rows.py
+++ b/tokenize_dataset_rows.py
@@ -40,7 +40,7 @@ def main():
     parser.add_argument("--jsonl_path", type=str, default="data/alpaca_data.jsonl")
     parser.add_argument("--save_path", type=str, default="data/alpaca")
     parser.add_argument("--max_seq_length", type=int, default=384)
-    parser.add_argument("--skip_overlength", type=bool, default=False)
+    parser.add_argument("--skip_overlength", action="store_true")
     args = parser.parse_args()
 
     dataset = datasets.Dataset.from_generator(


### PR DESCRIPTION
This PR fixed commands in README and removed `alpaca_data.jsonl` since it is generated from `alpaca_data.json`.